### PR TITLE
Fixed name generation bug (issue #26)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const {
   mkDirPromise,
   readFilePromiseRelative,
   writeFilePromise,
+	toPascalCase,
 } = require('./utils');
 
 // Load our package.json, so that we can pass the version onto `commander`.
@@ -47,7 +48,8 @@ program
   )
   .parse(process.argv);
 
-const [componentName] = program.args;
+const [componentNameRaw] = program.args;
+const componentName = toPascalCase(componentNameRaw)
 
 const options = program.opts();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,3 +58,20 @@ module.exports.readFilePromiseRelative = (fileLocation) =>
 module.exports.sample = (arr) => {
   return arr[Math.floor(Math.random() * arr.length)];
 };
+
+
+// Convert any word into PascalCase
+module.exports.toPascalCase = (string) => {
+  const anyNonLetterNorDigit = /([^a-zA-Z0-9])+(.)?/g
+  const anySpaceRemained = /[^a-zA-Z\d]/g
+  const uppercaseRegex = /^([A-Z])/
+
+  const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1);
+
+  let camelCase = string
+    .replace(anyNonLetterNorDigit, (_, __, char) => char ? char.toUpperCase() : '')
+    .replace(anySpaceRemained, '')
+    .replace(uppercaseRegex, (word) => word.toLowerCase());
+
+  return capitalize(camelCase)
+}


### PR DESCRIPTION
This PR will fix this issue https://github.com/joshwcomeau/new-component/issues/26

In doing so I also tried to standardize a little the component naming convention into PascalCase (either for the name of the file and the folder as well as the name of the function that it generates). 

e.g this commands now will work without errors: 
```bash
new-component a-component-with-hyphens # results in AComponentWithHyphens (folder,file and function name)
new-component a_component_with_underscores # results in AComponentWithUnderscores
new-component aCamelCaseComponent # results in ACamelCaseComponent
new-component "a component with spaces" # results in AComponentWithSpaces
```